### PR TITLE
Missing argument for -importv1from

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -76,7 +76,7 @@ then
 fi
 if [ ! -z "$CHIMITHEQUE_IMPORTV1FROM" ]
 then
-      importv1from="-importv1from"
+      importv1from="-importv1from $CHIMITHEQUE_IMPORTV1FROM"
 fi
 if [ ! -z "$CHIMITHEQUE_IMPORTFROM" ]
 then


### PR DESCRIPTION
When using docker, the argument is missing when using the ENV `CHIMITHEQUE_IMPORTV1FROM`